### PR TITLE
Sidebar entry + datasette 1.0a30 permission-API migration

### DIFF
--- a/datasette_pins/__init__.py
+++ b/datasette_pins/__init__.py
@@ -430,3 +430,30 @@ def register_permissions(datasette):
             default=False,
         ),
     ]
+
+
+PINS_ICON_SVG = """<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pin-map-fill" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M3.1 11.2a.5.5 0 0 1 .4-.2H6a.5.5 0 0 1 0 1H3.75L1.5 15h13l-2.25-3H10a.5.5 0 0 1 0-1h2.5a.5.5 0 0 1 .4.2l3 4a.5.5 0 0 1-.4.8H.5a.5.5 0 0 1-.4-.8z"/>
+  <path fill-rule="evenodd" d="M4 4a4 4 0 1 1 4.5 3.969V13.5a.5.5 0 0 1-1 0V7.97A4 4 0 0 1 4 3.999z"/>
+</svg>"""
+
+
+# Optional integration with `datasette-sidebar` — if the package is installed,
+# register a Pins entry in the sidebar's APPS section. The try/except keeps the
+# plugin import-clean when datasette-sidebar isn't present.
+try:
+    from datasette_sidebar.hookspecs import SidebarApp  # type: ignore[import-not-found]
+
+    @hookimpl
+    def datasette_sidebar_apps(datasette):
+        return [
+            SidebarApp(
+                label="Pins",
+                description="Databases, tables, and queries pinned to the homepage",
+                href="/-/datasette-pins/",
+                icon=PINS_ICON_SVG,
+                color="#276890",
+            )
+        ]
+except ImportError:
+    pass

--- a/datasette_pins/__init__.py
+++ b/datasette_pins/__init__.py
@@ -3,7 +3,8 @@ from .internal_migrations import internal_migrations
 from sqlite_utils import Database
 import json
 from functools import wraps
-from datasette import hookimpl, Response, Permission, Forbidden
+from datasette import hookimpl, Response, Forbidden
+from datasette.permissions import Action
 
 READ_PERMISSIONS = "datasette-pins-read"
 WRITE_PERMISSIONS = "datasette-pins-write"
@@ -14,12 +15,12 @@ def check_permission(write=False):
         @wraps(func)
         async def wrapper(scope, receive, datasette, request):
             if write:
-                result = await datasette.permission_allowed(
-                    request.actor, WRITE_PERMISSIONS, default=False
+                result = await datasette.allowed(
+                    action=WRITE_PERMISSIONS, actor=request.actor
                 )
             else:
-                result = await datasette.permission_allowed(
-                    request.actor, READ_PERMISSIONS, default=False
+                result = await datasette.allowed(
+                    action=READ_PERMISSIONS, actor=request.actor
                 )
             if not result:
                 raise Forbidden("Permission denied for datasette-pins")
@@ -152,8 +153,8 @@ class Routes:
 @hookimpl
 async def table_actions(datasette, actor, database, table):
     if not (
-        await datasette.permission_allowed(actor, READ_PERMISSIONS, default=False)
-        or await datasette.permission_allowed(actor, WRITE_PERMISSIONS, default=False)
+        await datasette.allowed(action=READ_PERMISSIONS, actor=actor)
+        or await datasette.allowed(action=WRITE_PERMISSIONS, actor=actor)
     ):
         return
     pin_id = await datasette.get_internal_database().execute(
@@ -212,8 +213,8 @@ async def table_actions(datasette, actor, database, table):
 @hookimpl
 async def database_actions(datasette, actor, database):
     if not (
-        await datasette.permission_allowed(actor, READ_PERMISSIONS, default=False)
-        or await datasette.permission_allowed(actor, WRITE_PERMISSIONS, default=False)
+        await datasette.allowed(action=READ_PERMISSIONS, actor=actor)
+        or await datasette.allowed(action=WRITE_PERMISSIONS, actor=actor)
     ):
         return
     pin_id = await datasette.get_internal_database().execute(
@@ -269,9 +270,9 @@ async def database_actions(datasette, actor, database):
 
 @hookimpl
 async def query_actions(datasette, actor, database, query_name):
-    if await datasette.permission_allowed(
-        actor, READ_PERMISSIONS, default=False
-    ) or await datasette.permission_allowed(actor, WRITE_PERMISSIONS, default=False):
+    if await datasette.allowed(
+        action=READ_PERMISSIONS, actor=actor
+    ) or await datasette.allowed(action=WRITE_PERMISSIONS, actor=actor):
         pin_id = await datasette.get_internal_database().execute(
             """
             select id
@@ -329,12 +330,8 @@ async def query_actions(datasette, actor, database, query_name):
 def top_homepage(datasette, request):
     async def f():
         if not (
-            await datasette.permission_allowed(
-                request.actor, READ_PERMISSIONS, default=False
-            )
-            or await datasette.permission_allowed(
-                request.actor, WRITE_PERMISSIONS, default=False
-            )
+            await datasette.allowed(action=READ_PERMISSIONS, actor=request.actor)
+            or await datasette.allowed(action=WRITE_PERMISSIONS, actor=request.actor)
         ):
             return ""
         rows = await datasette.get_internal_database().execute(
@@ -361,12 +358,8 @@ def top_homepage(datasette, request):
 def extra_css_urls(template, database, table, columns, view_name, request, datasette):
     async def inner():
         if view_name == "index" and (
-            await datasette.permission_allowed(
-                request.actor, READ_PERMISSIONS, default=False
-            )
-            or await datasette.permission_allowed(
-                request.actor, WRITE_PERMISSIONS, default=False
-            )
+            await datasette.allowed(action=READ_PERMISSIONS, actor=request.actor)
+            or await datasette.allowed(action=WRITE_PERMISSIONS, actor=request.actor)
         ):
             return [
                 datasette.urls.path(
@@ -382,12 +375,8 @@ def extra_css_urls(template, database, table, columns, view_name, request, datas
 def extra_js_urls(template, database, table, columns, view_name, request, datasette):
     async def inner():
         if view_name == "index" and (
-            await datasette.permission_allowed(
-                request.actor, READ_PERMISSIONS, default=False
-            )
-            or await datasette.permission_allowed(
-                request.actor, WRITE_PERMISSIONS, default=False
-            )
+            await datasette.allowed(action=READ_PERMISSIONS, actor=request.actor)
+            or await datasette.allowed(action=WRITE_PERMISSIONS, actor=request.actor)
         ):
             return [
                 datasette.urls.path(
@@ -411,23 +400,17 @@ def register_routes():
 
 
 @hookimpl
-def register_permissions(datasette):
+def register_actions(datasette):
     return [
-        Permission(
+        Action(
             name=WRITE_PERMISSIONS,
             abbr=None,
             description="Can pin, unpin, and re-order pins for datasette-pins",
-            takes_database=False,
-            takes_resource=False,
-            default=False,
         ),
-        Permission(
+        Action(
             name=READ_PERMISSIONS,
             abbr=None,
             description="Can read pinned items.",
-            takes_database=False,
-            takes_resource=False,
-            default=False,
         ),
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ classifiers=[
     "Framework :: Datasette",
     "License :: OSI Approved :: Apache Software License"
 ]
-requires-python = ">=3.8"
-dependencies = ["datasette>=1.0a14", "sqlite-migrate>=0.1b0"]
+requires-python = ">=3.10"
+dependencies = ["datasette>=1.0a30", "sqlite-migrate>=0.1b0"]
 
 
 [project.urls]

--- a/tests/test_pins.py
+++ b/tests/test_pins.py
@@ -33,3 +33,20 @@ async def test_permissions():
         cookies=cookie_for_actor(datasette, "unknown"),
     )
     assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_sidebar_app_registered():
+    # datasette-sidebar is an optional integration; only test when installed.
+    pytest.importorskip("datasette_sidebar")
+    from datasette.plugins import pm
+
+    datasette = Datasette(memory=True)
+    results = pm.hook.datasette_sidebar_apps(datasette=datasette)
+    apps = [app for result in results if result for app in result]
+    pins = [app for app in apps if app.label == "Pins"]
+    assert len(pins) == 1
+    pin = pins[0]
+    assert pin.resolve_href() == "/-/datasette-pins/"
+    assert "bi-pin-map-fill" in pin.icon
+    assert pin.description


### PR DESCRIPTION
- Adds the datasette-sidebar APPS entry for Pins.
- Migrates the removed `datasette.permission_allowed` -> `datasette.allowed` and `register_permissions` -> the `register_actions` hook (core 1.0a30).
- Bumps the floor to `datasette>=1.0a30` and `requires-python>=3.10` (required by the new API + core).

Enables datasette-pins to run alongside datasette-sidebar on current core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)